### PR TITLE
Adapted env_scale for past env in ancient.yml

### DIFF
--- a/src/mixs/schema/ancient.yml
+++ b/src/mixs/schema/ancient.yml
@@ -503,6 +503,39 @@ slots:
     range: string
     required: false
     recommended: true
+    past_env_broad:
+    description: "Report information about past broad environmental system the sample or specimen came from. The system(s) identified should provide the general environmental context of where the sample was burried (e.g. in the desert or a rainforest). We recommend using subclasses of EnvO s biome class:  http://purl.obolibrary.org/obo/ENVO_00000428. EnvO documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS"
+    title: broad-scale past environmental context
+    examples:
+    - value: "dessert biome [ENVO:01000247]"
+    in_subset:
+    - environment
+    keywords:
+    - context
+    - environmental
+    slot_uri: "MIXS:0000012"
+    range: string
+    required: true
+    pattern: "^([^\\s-]{1,2}|[^\\s-]+.+[^\\s-]+) \\[[a-zA-Z]{2,}:[a-zA-Z0-9]\\d+\\]$"
+    structured_pattern:
+      syntax: ^{termLabel} \[{termID}\]$
+      interpolated: true
+      partial_match: true
+  past_env_local:
+    annotations:
+      Expected_value: Report information about smaller environmental entities having causal influences upon the sample or speciment at/during the time of burial
+    description: "Report the entity or entities which are in the sample or specimen s local vicinity and which you believe have significant causal influences on your sample or specimen. We recommend using EnvO terms which are of smaller than your entry for past_env_broad_scale. Terms, such as anatomical sites, from other OBO Library ontologies which interoperate with EnvO (e.g. UBERON) are accepted in this field. EnvO documentation about how to use the field: https://github.com/EnvironmentOntology/envo/wiki/Using-ENVO-with-MIxS"
+    title: local past environmental context
+    examples:
+    - value: "hillside [ENVO:01000333]"
+    in_subset:
+    - environment
+    keywords:
+    - context
+    - environmental
+    string_serialization: '{termLabel} [{termID}]'
+    slot_uri: "MIXS:0000013"
+    required: true
   samp_alt_lab_ids:
     description: >-
       An alternative sample or material IDs related to the sample not already covered by terms samp_name and source_mat_id, including from associated other non-genetic analyses of the same sample (e.g. museum IDs, internal lab sample ID from sampling such a bone drilling). Can be specified multiple times for different ID contexts.
@@ -800,6 +833,8 @@ classes:
     is_a: Extension
     slots:
       - source_mat_curat_insti
+      - past_env_broad
+      - past_env_local
       - cultural_era
       - geological_epoch
       - damage_treatment
@@ -844,6 +879,12 @@ classes:
         slot_group: environment
       source_mat_curat_insti:
         rank: 2
+        slot_group: environment
+      past_env_broad:
+        rank: 3
+        slot_group: environment
+        past_env_local:
+        rank: 4
         slot_group: environment
       samp_alt_lab_ids:
         rank: 3


### PR DESCRIPTION
changed the namimg and descriptions of the env_broad_scale & env_local_scale to refer to past environment where the sample was buried