### PR TITLE
Replace age metadata terms with DarwinCore chronometric terms

### DIFF
--- a/src/mixs/schema/ancient.yml
+++ b/src/mixs/schema/ancient.yml
@@ -14,7 +14,7 @@ prefixes:
   xsd: http://www.w3.org/2001/XMLSchema#
   shex: http://www.w3.org/ns/shex#
   schema: http://schema.org/
-  chrono: http://rs.tdwg.org/chrono/iri/
+  chrono: http://rs.tdwg.org/chrono/terms/
 default_prefix: MIXS
 default_range: string
 subsets:


### PR DESCRIPTION
Close #15
Unfinished, we still need to check the issue comment (#15) and cross-ref with the MIxS TWG.