### PR TITLE
Created GeolEpochEnum based on stratigraphy.org chart alongside descriptions; update `geological_epoch` term to use fixed list

### DIFF
--- a/src/mixs/schema/ancient.yml
+++ b/src/mixs/schema/ancient.yml
@@ -82,6 +82,7 @@ enums:
       historical records:
       other:
   GeolEpochEnum:
+    description: Chronometric epochs defined by the International Chronostratigraphic Chart (v2024-12) of the International Commission on Stratigraphy (https://stratigraphy.org/chart/)
     permissible_values:
       Holocene:
         description: A time period from 0.0117 million years ago to the present.


### PR DESCRIPTION
Created the GeolEpochEnum using the Int. Commission. on Stratigraphies' Interantional Chronometric Chart to define the Epochs: https://stratigraphy.org/chart/ (Changed the headers to chonometric). Used all the Epoch listed (up to Terreneuvian) and added the time range as description based on the website. 

Closes #31 