### PR TITLE
Update damage_treatment instructions to specify procedure when exact type of removal unknown

### DIFF
--- a/src/mixs/schema/ancient.yml
+++ b/src/mixs/schema/ancient.yml
@@ -233,7 +233,7 @@ slots:
       Expected_value: enumeration
     description: >-
       Indication of whether characteristic ancient DNA damage has been altered or removed from a DNA extract in a laboratory.
-      If damage has been removed, but whether full or partial is unknown - specify 'other', and describe known information in `experimental_sop` and related free text descriptive terms.
+      If damage has been removed, but whether it was fully or partially removed is unknown (e.g. with UDG treatment) - specify 'other', and describe known information in `experimental_sop` and related free text descriptive terms.
     title: Damage treatment type
     examples:
       - value: none

--- a/src/mixs/schema/ancient.yml
+++ b/src/mixs/schema/ancient.yml
@@ -232,8 +232,8 @@ slots:
     annotations:
       Expected_value: enumeration
     description: >-
-      Indication of whether characteristic ancient DNA damage has been 
-      altered or removed from a DNA extract in a laboratory
+      Indication of whether characteristic ancient DNA damage has been altered or removed from a DNA extract in a laboratory.
+      If damage has been removed, but whether full or partial is unknown - specify 'other', and describe known information in `experimental_sop` and related free text descriptive terms.
     title: Damage treatment type
     examples:
       - value: none


### PR DESCRIPTION
Clarified the description of damage treatment in ancient DNA.