### PR TITLE
Updated 'permit_authority' term to required

### DIFF
--- a/src/mixs/schema/ancient.yml
+++ b/src/mixs/schema/ancient.yml
@@ -305,7 +305,7 @@ slots:
     slot_uri: MIXS:999999905
     multivalued: true
     range: string
-    required: false
+    required: true
     recommended: true
   permit_date:
     description: >-


### PR DESCRIPTION
Updated the term 'permit_authority' to required to ensure appropriate permission was requested from the relevant authority. If no permit is needed, it can be specified in the field.