### PR TITLE
Rename `mid_config` to `lib_mid_desc`

### DIFF
--- a/src/mixs/schema/ancient.yml
+++ b/src/mixs/schema/ancient.yml
@@ -902,7 +902,7 @@ slots:
       partial_match: true
     required: false
     recommended: false
-  mid_config:
+  lib_mid_desc:
     annotations:
       Expected_value: Description of the indexing configuration of the library
     description: >-
@@ -1181,7 +1181,7 @@ classes:
       - damage_treatment
       - nucl_acid_extr_date
       - experimental_sop
-      - mid_config
+      - lib_mid_desc
       - library_name
       - lib_polymerase
       - lib_strandedness
@@ -1296,7 +1296,7 @@ classes:
       experimental_sop:
         slot_group: Nucleic acid source
         rank: 34
-      mid_config:
+      lib_mid_desc:
         slot_group: Sequencing
         rank: 35
       library_name:

--- a/src/mixs/schema/ancient.yml
+++ b/src/mixs/schema/ancient.yml
@@ -907,7 +907,7 @@ slots:
       Expected_value: Description of the indexing configuration of the library
     description: >-
       Index/barcode/primer configuration used during library building for sequencing. This includes information such as the number, type and location of indexes, the index/primer kit/list, or if 'inline' barcodes or UMIs were ligated directly onto the template molecules.
-    title: multiplex identifiers or indexing configuration of libraries
+    title: description of library multiplex identifiers or indexing configuration
     examples:
       - value: "dual index with single internal barcode."
       - value: "UDI index sequences."


### PR DESCRIPTION
close #100 

Make it clearer what the content of the term is (free text description, rather than a structure 'configuration')