### PR TITLE
Update palaeopath_status description to include subject as well as individual

### DIFF
--- a/src/mixs/schema/ancient.yml
+++ b/src/mixs/schema/ancient.yml
@@ -776,7 +776,7 @@ slots:
     annotations:
       Expected_value: description of health related observation on ancient remains
     description: >-
-      Describe briefly any relevant palaeopathological or health-related observations of the remains of the individual under study.
+      Describe briefly any relevant palaeopathological or health-related observations of the remains of the individual/subject under study.
     title: palaeopathology status
     examples:
       - value: "Osteoporosis."

--- a/src/mixs/schema/ancient.yml
+++ b/src/mixs/schema/ancient.yml
@@ -776,7 +776,7 @@ slots:
     annotations:
       Expected_value: description of health related observation on ancient remains
     description: >-
-      Describe briefly any relevant palaeopathological or health-related observations of the remains of the individual/subject under study.
+      Describe briefly any relevant palaeopathological or health-related observations of the remains of the individual or subject under study.
     title: palaeopathology status
     examples:
       - value: "Osteoporosis."


### PR DESCRIPTION
close #119 

Updated the 'palaeopath_status' description to include 'individual/subject'. Hence, the description now reads: "Describe briefly any relevant palaeopathological or health-related observations of the remains of the individual/subject under study".