### PR TITLE
Deprecate `column_sample_depth` 

### DIFF
--- a/src/mixs/schema/ancient.yml
+++ b/src/mixs/schema/ancient.yml
@@ -386,33 +386,6 @@ slots:
     range: string
     required: false
     recommended: false
-  column_sample_depth:
-    annotations:
-      Expected_value: depth of the sample in the column of a stratigraphy or sediment core
-    description: >-
-      Distance relative to the top or beginning of the sediment core or stratigraphic sequence (defined by the term 'depth') from which the sample was taken.
-      This is not necessarily the same as the depth from floor level or Mean Sea Level (MSL) (which should be defined using the term: depth), as a core could start part way below the surface.
-      Can also be a range if the depth of the sample is not precisely measured.
-    title: sample depth in column
-    examples:
-      - value: "34 cm"
-      - value: "23 - 56 cm"
-      - value: "100 in"
-    in_subset:
-      - environment
-    keywords:
-      - environment
-      - core
-      - sediment
-    slot_uri: MIXS:999999908 #Not assigned
-    multivalued: false
-    range: string
-    required: false
-    recommended: false
-    structured_pattern:
-      syntax: ^{scientific_float}( *- *{scientific_float})? *{text}$
-      interpolated: true
-      partial_match: true
   context_retrieval_date:
     annotations:
       Preferred_unit: year
@@ -1154,7 +1127,6 @@ classes:
       - past_env_broad
       - past_env_local
       - stratigraph_context
-      - column_sample_depth
       - context_retrieval_date
       - permit_id
       - permit_authority
@@ -1218,120 +1190,117 @@ classes:
       stratigraph_context:
         slot_group: Environment
         rank: 8
-      column_sample_depth:
-        slot_group: Environment
-        rank: 9
       permit_id:
         slot_group: Sample body
-        rank: 10
+        rank: 9
       permit_authority:
         slot_group: Sample body
-        rank: 11
+        rank: 10
       permit_date:
         slot_group: Sample body
-        rank: 12
+        rank: 11
       permit_scope:
         slot_group: Sample body
-        rank: 13
+        rank: 12
       biocultural_label:
         slot_group: Sample body
-        rank: 14
+        rank: 13
       samp_alt_lab_ids:
         slot_group: Sample body
-        rank: 15
+        rank: 14
       prev_pubs:
         slot_group: Sample body
-        rank: 16
+        rank: 15
       host_preserv_state:
         slot_group: Sample body
-        rank: 17
+        rank: 16
       storage_conditions:
         slot_group: Sample body
-        rank: 18
+        rank: 17
       samp_preserv_treatm:
         slot_group: Sample body
-        rank: 19
+        rank: 18
       cultural_era:
         slot_group: Sample body
-        rank: 20
+        rank: 19
       geological_epoch:
         slot_group: Sample body
-        rank: 21
+        rank: 20
       earliest_chrono_age:
         slot_group: Sample body
-        rank: 22
+        rank: 21
       earliest_chrono_sys:
         slot_group: Sample body
-        rank: 23
+        rank: 22
       latest_chrono_age:
         slot_group: Sample body
-        rank: 24
+        rank: 23
       latest_chrono_sys:
         slot_group: Sample body
-        rank: 25
+        rank: 24
       chrono_age_protocol:
         slot_group: Sample body
-        rank: 26
+        rank: 25
       chrono_age_remarks:
         slot_group: Sample body
-        rank: 27
+        rank: 26
       palaeopath_status:
         slot_group: Sample body
-        rank: 28
+        rank: 27
       batch_ids:
         slot_group: Nucleic acid source
-        rank: 29
+        rank: 28
       neg_cont_status:
         slot_group: Nucleic acid source
-        rank: 30
+        rank: 29
       samp_decont_pretreat:
         slot_group: Nucleic acid source
-        rank: 31
+        rank: 30
       damage_treatment:
         slot_group: Nucleic acid source
-        rank: 32
+        rank: 31
       nucl_acid_extr_date:
         slot_group: Nucleic acid source
-        rank: 33
+        rank: 32
       experimental_sop:
         slot_group: Nucleic acid source
-        rank: 34
+        rank: 33
       mid_config:
         slot_group: Sequencing
-        rank: 35
+        rank: 34
       library_name:
         slot_group: Sequencing
-        rank: 36
+        rank: 35
       lib_polymerase:
         slot_group: Sequencing
-        rank: 37
+        rank: 36
       lib_strandedness:
         slot_group: Sequencing
-        rank: 38
+        rank: 37
       lib_preparation_sop:
         slot_group: Sequencing
-        rank: 39
+        rank: 38
       lib_type:
         slot_group: Sequencing
-        rank: 40
+        rank: 39
       num_reamp_cycles:
         slot_group: Sequencing
-        rank: 41
+        rank: 40
       num_capture_cycles:
         slot_group: Sequencing
-        rank: 42
+        rank: 41
       capture_probe_taxid:
         slot_group: Sequencing
-        rank: 43
+        rank: 42
       capture_probe_desc:
         slot_group: Sequencing
-        rank: 44
+        rank: 43
       desc_read_state:
         slot_group: Data analysis
-        rank: 45
+        rank: 44
       data_filt_applied:
         slot_group: Data analysis
-        rank: 46
+        rank: 45
     class_uri: MIXS:9999903
     annotations:
       use_cases: ancient dna samples


### PR DESCRIPTION
As it too close to the existing MIxS `depth`, but we should also add a `mapping` to the DarwinCore term in the in the MIxS term (when we submit all of our PRs)