### PR TITLE
Remove sediment core example from `batch_ids`

### DIFF
--- a/src/mixs/schema/ancient.yml
+++ b/src/mixs/schema/ancient.yml
@@ -807,7 +807,6 @@ slots:
       - value: "Extraction batch: 1"
       - value: "20260501-A2 (extraction);20202607-B2 (library)"
       - value: "ExtrMG;LibMG;SeqMG"
-      - value: "Core: North-East Greenland 73G"
     in_subset:
       - nucleic acid sequence source
     keywords:


### PR DESCRIPTION
To close #109

As such a thing should be covered by sample IDs etc 