### PR TITLE
Add `close_mappings` to dwc terms for `permit_scope`

### DIFF
--- a/src/mixs/schema/ancient.yml
+++ b/src/mixs/schema/ancient.yml
@@ -492,6 +492,9 @@ slots:
     keywords:
       - ethics
     slot_uri: MIXS:999999913 #Not assigned
+    close_mappings:
+      - dwc:accessRights
+      - dwc:license
     multivalued: true
     range: string
     string_serialization: "{text}"

--- a/src/mixs/schema/ancient.yml
+++ b/src/mixs/schema/ancient.yml
@@ -493,8 +493,8 @@ slots:
       - ethics
     slot_uri: MIXS:999999913 #Not assigned
     close_mappings:
-      - dwc:accessRights
-      - dwc:license
+      - dc:accessRights
+      - dc:license
     multivalued: true
     range: string
     string_serialization: "{text}"


### PR DESCRIPTION
close #113 

Added Darwin Core terms [accessRights](https://dwc.tdwg.org/terms/#dcterms:accessRights) and [license](https://dwc.tdwg.org/terms/#dcterms:license) as close mappings for MInAS term `permit_scope`, following [this](https://github.com/GenomicsStandardsConsortium/mixs/issues/1142#issuecomment-4109152679) suggestion.