### PR TITLE
Enhance polymerase description in ancient.yml

### DIFF
--- a/src/mixs/schema/ancient.yml
+++ b/src/mixs/schema/ancient.yml
@@ -945,7 +945,7 @@ slots:
     annotations:
       Expected_value: name of polymerase used during library construction
     description: >-
-      The polymerase enzyme used for building nucleic acid libraries.
+      The polymerase enzyme used for building nucleic acid libraries. Include formal identifier e.g. SKU or the manufacturers name at minimum.
     title: library polymerase
     examples:
       - value: "Agilent PfuTurbo Cx HotStart"


### PR DESCRIPTION
close #120

Expanded description of the polymerase enzyme used for library construction to include formal identifiers. Asked to include formal identifier e.g. SKU or the manufacturers name at minimum.