### PR TITLE
Abbreviated the two titles containing 'capture' to 'capt' for consistency (capt_pcr_cyc_tot & capt_probe_desc)

### DIFF
--- a/src/mixs/schema/ancient.yml
+++ b/src/mixs/schema/ancient.yml
@@ -1022,7 +1022,7 @@ slots:
   capt_pcr_cyc_tot:
     description: >-
       Amplification cycles after capture enrichment total. Provide additional information about PCR conditions in pcr_cond
-    title: number of reamplification cycles after capture
+    title: post capture PCR reamplication cycles total
     examples:
       - value: "12"
     in_subset:
@@ -1060,7 +1060,7 @@ slots:
       Expected_value: Description of probe set used for target enrichment/library selection (a.k.a. capture)
     description: >-
       Description of target enrichment probe designs used (e.g., species included, sequences, type, company). This can include custom kits (please provide a general description and DOI if available) or commercially available kit (provide ID and company).
-    title: enrichment probe design description
+    title: capture probe design description
     examples:
       - value: "Custom probe design (70 bp biotinylated RNA probes) covering 500 full E. Coli genomes; company TE-Science"
       - value: "Commercial RNA baits kit ABC001-EC from company TE-Science, purchased 2020"

--- a/src/mixs/schema/ancient.yml
+++ b/src/mixs/schema/ancient.yml
@@ -1019,7 +1019,7 @@ slots:
       - sequencing
     slot_uri: MIXS:999999941 #Not assigned
     range: integer
-  capture_pcr_cyc_tot:
+  capt_pcr_cyc_tot:
     description: >-
       Amplification cycles after capture enrichment total. Provide additional information about PCR conditions in pcr_cond
     title: number of reamplification cycles after capture
@@ -1055,7 +1055,7 @@ slots:
     string_serialization:
     required: false
     recommended: false
-  capture_probe_desc:
+  capt_probe_desc:
     annotations:
       Expected_value: Description of probe set used for target enrichment/library selection (a.k.a. capture)
     description: >-
@@ -1181,9 +1181,9 @@ classes:
       - lib_gener_technique
       - sop_lib_preparation
       - reamp_pcr_cyc_tot
-      - capture_pcr_cyc_tot
+      - capt_pcr_cyc_tot
       - capture_probe_taxid
-      - capture_probe_desc
+      - capt_probe_desc
       - data_preproc_desc
       - reads_removed_desc
     slot_usage:
@@ -1307,13 +1307,13 @@ classes:
       reamp_pcr_cyc_tot:
         slot_group: Sequencing
         rank: 40
-      capture_pcr_cyc_tot:
+      capt_pcr_cyc_tot:
         slot_group: Sequencing
         rank: 41
       capture_probe_taxid:
         slot_group: Sequencing
         rank: 42
-      capture_probe_desc:
+      capt_probe_desc:
         slot_group: Sequencing
         rank: 43
       data_preproc_desc:


### PR DESCRIPTION
Close #140 

As we adopted the abbreviation 'capt' in the title "capt_probe_src_taxid" to mean 'capture' (to stay within the 20-characters limit; see https://github.com/MIxS-MInAS/extension-ancient/pull/139), and to ensure consistency, we updated the term 'capture' to the abbreviation 'capt' in all titles. 

These consisted of the following:
capture_pcr_cyc_tot -> capt_pcr_cyc_tot 
capture_probe_desc -> capt_probe_desc

Note: as PR https://github.com/MIxS-MInAS/extension-ancient/pull/139 has not yet been merged, the current yaml file does not display the new term "capt_probe_src_taxid" for "capture_probe_taxid". I have decided to leave it as such so as not to cause conflicts, as I assume PR 139 will take care of updating the term. 

I also confirm that the word 'source' abbreviated as 'src' does not feature in any of the other titles, so there is no need for an update of the abbreviation.