### PR TITLE
Refine definition of `sample_alt_lab_ids` to remove ambiguous reference to museum IDs that are already represented by `source_mat_id` 

### DIFF
--- a/src/mixs/schema/ancient.yml
+++ b/src/mixs/schema/ancient.yml
@@ -511,7 +511,9 @@ slots:
     recommended: true
   samp_alt_lab_ids:
     description: >-
-      An alternative sample or material IDs related to the sample not already covered by terms samp_name and source_mat_id, including from associated other non-genetic analyses of the same sample (e.g. museum IDs, internal lab sample ID from sampling such a bone drilling). Can be specified multiple times for different ID contexts.
+      An alternative sample or material ID related to the sample not already covered by terms samp_name and source_mat_id, including from associated other non-genetic analyses of the same sample, that can be used synonymously with the main ID.
+      For example: external database IDs, internal lab sample ID from sampling such a bone drilling, or IDs from other scientific analyses.
+      Can be specified multiple times for different ID contexts.
     title: alternative sample IDs
     examples:
       - value: "ABC_24"

--- a/src/mixs/schema/ancient.yml
+++ b/src/mixs/schema/ancient.yml
@@ -512,7 +512,7 @@ slots:
   samp_alt_lab_ids:
     description: >-
       An alternative sample or material ID related to the sample not already covered by terms samp_name and source_mat_id, including from associated other non-genetic analyses of the same sample, that can be used synonymously with the main ID.
-      For example: external database IDs, internal lab sample ID from sampling such a bone drilling, or IDs from other scientific analyses.
+      For example: external database IDs, internal lab sample ID from sampling such as bone drilling, or IDs from other scientific analyses.
       Can be specified multiple times for different ID contexts.
     title: alternative sample IDs
     examples:


### PR DESCRIPTION
To address the comment here: https://github.com/GenomicsStandardsConsortium/mixs/issues/1146#issuecomment-4336673578 and  #141 