### PR TITLE
Rename `experimental_sop` to `sop_experimental` to follow new convention, and add relaxed definition of existing MIxS `sop`

### DIFF
--- a/src/mixs/schema/ancient.yml
+++ b/src/mixs/schema/ancient.yml
@@ -1121,7 +1121,7 @@ slots:
       Expected_value:
         tag: Expected_value
         value: reference to SOP
-    description: Standard operating procedures used in to generate genomes,
+    description: Standard operating procedures used to generate genomes,
       metagenomes or environmental sequences
     title: relevant standard operating procedures
     examples:

--- a/src/mixs/schema/ancient.yml
+++ b/src/mixs/schema/ancient.yml
@@ -55,7 +55,7 @@ enums:
       damage-selection:
         description: Library preparation-derived technique that retain only molecules containing damage, and have discarded those without damage.
       other:
-        description: Other type of damage treatment that are further described in other method description terms. If damage has been removed, but whether full or partial is unknown - use this option and describe known information in `sop_experimental` and related free text descriptive terms.
+        description: Other types of damage treatment that are further described in other method description terms. If damage has been removed, but whether full or partial is unknown - use this option and describe known information in `sop_experimental` and related free text descriptive terms.
   LibTypeEnum:
     description: >-
       Options for types of DNA that have been targeted for DNA library construction.

--- a/src/mixs/schema/ancient.yml
+++ b/src/mixs/schema/ancient.yml
@@ -55,7 +55,7 @@ enums:
       damage-selection:
         description: Library preparation-derived technique that retain only molecules containing damage, and have discarded those without damage.
       other:
-        description: Other type of damage treatment that are further described in other method description terms. If damage has been removed, but whether full or partial is unknown - use this option and describe known information in `experimental_sop` and related free text descriptive terms.
+        description: Other type of damage treatment that are further described in other method description terms. If damage has been removed, but whether full or partial is unknown - use this option and describe known information in `sop_experimental` and related free text descriptive terms.
   LibTypeEnum:
     description: >-
       Options for types of DNA that have been targeted for DNA library construction.
@@ -849,7 +849,7 @@ slots:
       Expected_value: enumeration
     description: >-
       Indication of whether characteristic ancient DNA damage has been altered or removed from a DNA extract in a laboratory.
-      If damage has been removed, but whether it was fully or partially removed is unknown (e.g. with UDG treatment) - specify 'other', and describe known information in `experimental_sop` and related free text descriptive terms.
+      If damage has been removed, but whether it was fully or partially removed is unknown (e.g. with UDG treatment) - specify 'other', and describe known information in `sop_experimental` and related free text descriptive terms.
     title: damage treatment type
     examples:
       - value: none
@@ -876,11 +876,11 @@ slots:
     range: datetime ## or name of defined enum as above
     required: false
     recommended: false
-  experimental_sop:
+  sop_experimental:
     description: >-
       Provide a DOI or URL to refer to the paper where the field report, nucleic acid extraction, 
       library construction, and other procedures are explained in more detail, e.g. the paper reporting the data.
-    title: experimental procedures
+    title: experimental standard operating procedure
     examples:
       - value: doi:10.1093/nar/gkr771
     in_subset:
@@ -1116,6 +1116,42 @@ slots:
     range: boolean
     required: false
     recommended: true
+  sop:
+    annotations:
+      Expected_value:
+        tag: Expected_value
+        value: reference to SOP
+    description: Standard operating procedures used in to generate genomes,
+      metagenomes or environmental sequences
+    title: relevant standard operating procedures
+    examples:
+      - value: http://press.igsb.anl.gov/earthmicrobiome/protocols-and-standards/its/
+    in_subset:
+      - sequencing
+    from_schema: https://w3id.org/mixs
+    keywords:
+      - procedures
+    slot_uri: MIXS:0000090
+    alias: sop
+    domain_of:
+      - MimsMisip
+      - MigsBa
+      - MigsEu
+      - MigsOrg
+      - MigsPl
+      - MigsVi
+      - Mimag
+      - MimarksC
+      - MimarksS
+      - Mims
+      - Misag
+      - Miuvig
+      - Agriculture
+    range: string
+    multivalued: true
+    structured_pattern:
+      syntax: ^({PMID}|{DOI}|{URL})$
+      interpolated: true
 classes:
   MixsCompliantData:
     description:
@@ -1173,7 +1209,7 @@ classes:
       - samp_decont_pretreat
       - damage_treatment
       - nucl_acid_extr_date
-      - experimental_sop
+      - sop_experimental
       - lib_mid_desc
       - library_name
       - lib_polymerase
@@ -1283,7 +1319,7 @@ classes:
       nucl_acid_extr_date:
         slot_group: Nucleic acid source
         rank: 32
-      experimental_sop:
+      sop_experimental:
         slot_group: Nucleic acid source
         rank: 33
       lib_mid_desc:


### PR DESCRIPTION
To close #145 
To address comment in https://github.com/GenomicsStandardsConsortium/mixs/issues/1165#issuecomment-4378639902